### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest,prefer-stable]
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2,8.3,8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest,prefer-stable]
 
-    name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
         "php": "^8.2"
     },
     "require-dev": {
-        "spatie/laravel-backup": "^9.0",
+        "spatie/laravel-backup": "^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^11.0",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- add Testbench 10 and 11 support
- add Laravel 10, 11, 12, and 13 coverage to the CI matrix
- add PHP 8.5 to the CI matrix

## Testing
- composer update
- vendor/bin/phpunit
